### PR TITLE
Support filehandles

### DIFF
--- a/lib/Spreadsheet/Wright.pm
+++ b/lib/Spreadsheet/Wright.pm
@@ -22,6 +22,10 @@ sub new
 	
 	if (lc $format eq 'auto')
 	{
+		if (!defined $filename)
+		{
+			die 'Format auto is not supported without file name';
+		}
 		$format = ($filename =~ /\.([^\.]+)$/) ? lc($1) : 'auto';
 	}
 	

--- a/lib/Spreadsheet/Wright/CSV.pm
+++ b/lib/Spreadsheet/Wright/CSV.pm
@@ -21,8 +21,16 @@ sub new
 	my ($class, %args) = @_;
 	my $self = bless {}, $class;
 	
-	$self->{'_FILENAME'} = $args{'file'} // $args{'filename'}
-		or croak "Need filename";
+	my $fh = $args{'fh'} // $args{'filehandle'};
+	if ($fh)
+	{
+		$self->{'_FH'} = $fh;
+	}
+	else
+	{
+		$self->{'_FILENAME'} = $args{'file'} // $args{'filename'}
+			or croak "Need filename";
+	}
 
 	$args{'csv_options'}{'eol'}      //= "\r\n";
 	$args{'csv_options'}{'sep_char'} //= ",";

--- a/lib/Spreadsheet/Wright/Excel.pm
+++ b/lib/Spreadsheet/Wright/Excel.pm
@@ -19,9 +19,18 @@ sub new
 {
 	my ($class, %args) = @_;
 	my $self = bless {}, $class;
-	
-	$self->{'_FILENAME'}  = $args{'file'} // $args{'filename'}
-		or croak "Need filename.";
+
+	my $fh = $args{'fh'} // $args{'filehandle'};
+	if ($fh)
+	{
+		$self->{'_FH'} = $fh;
+	}
+	else
+	{
+		$self->{'_FILENAME'} = $args{'file'} // $args{'filename'}
+			or croak "Need filename";
+	}
+
 	$self->{'_SHEETNAME'} = $args{'sheet'}  // '';
 	$self->{'_STYLES'}    = $args{'styles'} // {};
 		

--- a/lib/Spreadsheet/Wright/JSON.pm
+++ b/lib/Spreadsheet/Wright/JSON.pm
@@ -19,8 +19,18 @@ sub new
 {
 	my ($class, %args) = @_;
 	my $self = bless { 'options' => \%args }, $class;
-	$self->{'_FILENAME'} = $args{'file'} // $args{'filename'}
-		or croak "Need filename.";
+
+	my $fh = $args{'fh'} // $args{'filehandle'};
+	if ($fh)
+	{
+		$self->{'_FH'} = $fh;
+	}
+	else
+	{
+		$self->{'_FILENAME'} = $args{'file'} // $args{'filename'}
+			or croak "Need filename";
+	}
+
 	$self->{'_WORKSHEET'} = $args{'sheet'} // 'Sheet1';
 	return $self;
 }

--- a/lib/Spreadsheet/Wright/OOXML.pm
+++ b/lib/Spreadsheet/Wright/OOXML.pm
@@ -17,11 +17,19 @@ use Excel::Writer::XLSX;
 sub new
 {
 	my ($class, %args) = @_;
-	
 	my $self = bless { 'options' => \%args }, $class;
-	
-	$self->{'_FILENAME'} = $args{'file'} // $args{'filename'}
-		or croak "Need filename.";
+
+	my $fh = $args{'fh'} // $args{'filehandle'};
+	if ($fh)
+	{
+		$self->{'_FH'} = $fh;
+	}
+	else
+	{
+		$self->{'_FILENAME'} = $args{'file'} // $args{'filename'}
+			or croak "Need filename";
+	}
+
 	$self->{'_SHEETNAME'} = $args{'sheet'}  || '';
 	$self->{'_STYLES'}    = $args{'styles'} || {};
 

--- a/lib/Spreadsheet/Wright/OpenDocumentXML.pm
+++ b/lib/Spreadsheet/Wright/OpenDocumentXML.pm
@@ -26,11 +26,18 @@ use constant {
 sub new
 {
 	my ($class, %args) = @_;
-	
 	my $self = bless { 'options' => \%args }, $class;
-	
-	$self->{'_FILENAME'} = $args{'file'} // $args{'filename'}
-		or croak "Need filename.";
+
+	my $fh = $args{'fh'} // $args{'filehandle'};
+	if ($fh)
+	{
+		$self->{'_FH'} = $fh;
+	}
+	else
+	{
+		$self->{'_FILENAME'} = $args{'file'} // $args{'filename'}
+			or croak "Need filename";
+	}
 
 	return $self;
 }

--- a/lib/Spreadsheet/Wright/XHTML.pm
+++ b/lib/Spreadsheet/Wright/XHTML.pm
@@ -24,8 +24,16 @@ sub new
 	
 	my $self = bless { 'options' => \%args }, $class;
 	
-	$self->{'_FILENAME'} = $args{'file'} // $args{'filename'}
-		or croak "Need filename.";
+	my $fh = $args{'fh'} // $args{'filehandle'};
+	if ($fh)
+	{
+		$self->{'_FH'} = $fh;
+	}
+	else
+	{
+		$self->{'_FILENAME'} = $args{'file'} // $args{'filename'}
+			or croak "Need filename";
+	}
 
 	return $self;
 }

--- a/t/03fh.t
+++ b/t/03fh.t
@@ -1,0 +1,26 @@
+use Test::More tests => 1;
+use Spreadsheet::Wright;
+
+SKIP: {
+	my $contents;
+	open my $handle, '>', \$contents
+		or skip "cannot open a filehandle to string.", 1;
+
+	my $h = Spreadsheet::Wright->new(filehandle => $handle, format => 'csv',
+									 csv_options=>{eol=>"\n"});
+	$h->addrow('Name', 'Discovery');
+	$h->addrows(
+		['Archimedes', 'Water displacement'],
+		['Albert Einstein', 'General relativity'],
+		);
+	$h->close;
+
+	is($contents, <<'DATA', 'CSV output to filehandle works');
+Name,Discovery
+Archimedes,"Water displacement"
+"Albert Einstein","General relativity"
+DATA
+
+	unlink $FN;
+}
+


### PR DESCRIPTION
This PR implements support for filehandles, which could be passed to constructors instead of `filename`. When supplied, spreadsheets are printed to the filehandle instead of a file with a given name.

Rationale:
* Allows output to STDOUT with `new->( filehandle =>\*STDOUT, format => 'csv' )`
* Allows output to a string with `new->( filehandle => \$string_to_store_content, format => 'csv' )`

API changes:
* Constructor parameter `filename` becomes senseless when `filehandle` is provided;
* Constructor parameter `format` with value other than `auto` becomes mandatory with `filehandle`.

The PR contains a simple test case.